### PR TITLE
#OBS-I230: fix: proceed button enabled when data key is empty

### DIFF
--- a/client/src/pages/dataset/wizard/components/DataKeySelection.tsx
+++ b/client/src/pages/dataset/wizard/components/DataKeySelection.tsx
@@ -29,7 +29,7 @@ const DataKeySelection = (props: any) => {
     })
 
     const pushStateToStore = (values: Record<string, any>) => dispatch(addState({ id, ...values, error: _.keys(formErrors).length > 0 }));
-    const setStoreToError = () => dispatch(addState({ id, ...existingState || {}, error: existingState ? false : true }));
+    const setStoreToError = () => dispatch(addState({ id, ...existingState || {}, error: _.get(existingState, "dataKey") ? false : true }));
     const onSubmission = (value: any) => { };
 
     useEffect(() => {

--- a/client/src/services/datasetState.ts
+++ b/client/src/services/datasetState.ts
@@ -185,9 +185,10 @@ const getJsonSchemaState = async (dataset: Record<string, any>) => {
 
 const getDataKeyState = (dataset: Record<string, any>) => {
     const { dataset_config } = dataset;
+    const dataKey = dataset_config?.keys_config?.data_key || _.get(dataset_config, "data_key")
     return {
-        error: false,
-        dataKey: dataset_config?.keys_config?.data_key || _.get(dataset_config, "data_key")
+        error: !dataKey,
+        dataKey
     }
 }
 


### PR DESCRIPTION
**Description:**
1. Fixed the enabling of button even when the data key was not selected in master dataset flow