### PR TITLE
build: migrate Docker base image to Docker Hardened Images (DHI)

### DIFF
--- a/.github/workflows/build_and_deployment.yaml
+++ b/.github/workflows/build_and_deployment.yaml
@@ -32,6 +32,13 @@ jobs:
           username: ${{ vars.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
+      - name: Login to dhi.io (Docker Hardened Images)
+        uses: docker/login-action@v3
+        with:
+          registry: dhi.io
+          username: ${{ vars.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
       - name: Build docker image and push
         uses: docker/build-push-action@v4
         with:

--- a/.github/workflows/build_and_deployment.yaml
+++ b/.github/workflows/build_and_deployment.yaml
@@ -47,7 +47,19 @@ jobs:
         uses: docker/build-push-action@v4
         with:
           push: true
+          sbom: true
+          provenance: true
           tags: ${{ vars.DOCKERHUB_USERNAME }}/obsrv-web-console:${{ steps.meta.outputs.tag }}
+
+      # Report-only (continue-on-error). web-console is 0 Critical/High today.
+      - name: Docker Scout — CVE scan (report-only)
+        uses: docker/scout-action@v1
+        continue-on-error: true
+        with:
+          command: cves
+          image: ${{ vars.DOCKERHUB_USERNAME }}/obsrv-web-console:${{ steps.meta.outputs.tag }}
+          only-severities: critical,high
+          sarif-file: scout-web-console.sarif.json
 
   aws-deploy:
     needs: [check-tag, docker-build]

--- a/.github/workflows/build_and_deployment.yaml
+++ b/.github/workflows/build_and_deployment.yaml
@@ -47,8 +47,6 @@ jobs:
         uses: docker/build-push-action@v4
         with:
           push: true
-          sbom: true
-          provenance: true
           tags: ${{ vars.DOCKERHUB_USERNAME }}/obsrv-web-console:${{ steps.meta.outputs.tag }}
 
       # Report-only (continue-on-error). web-console is 0 Critical/High today.

--- a/.github/workflows/build_and_deployment.yaml
+++ b/.github/workflows/build_and_deployment.yaml
@@ -39,11 +39,15 @@ jobs:
           username: ${{ vars.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
+      - name: Compute image tag (sanitize ref name → valid Docker tag)
+        id: meta
+        run: echo "tag=$(echo -n '${{ github.ref_name }}' | sed 's#[^a-zA-Z0-9._-]#-#g')" >> "$GITHUB_OUTPUT"
+
       - name: Build docker image and push
         uses: docker/build-push-action@v4
         with:
           push: true
-          tags: ${{ vars.DOCKERHUB_USERNAME }}/obsrv-web-console:${{ github.ref_name }}
+          tags: ${{ vars.DOCKERHUB_USERNAME }}/obsrv-web-console:${{ steps.meta.outputs.tag }}
 
   aws-deploy:
     needs: [check-tag, docker-build]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,6 @@
 
 # Stage 1 - Build the React client and Node.js server
-FROM --platform=linux/amd64 node:24.13.1-slim AS build
-RUN apt-get update \
- && apt-get install -y --no-install-recommends ca-certificates openssl \
- && apt-get upgrade -y \
- && rm -rf /var/lib/apt/lists/*
+FROM dhi.io/node:24-debian13-dev AS build
 
 # Build React client v2
 WORKDIR /opt/app/web-console-v2
@@ -24,27 +20,10 @@ RUN cp -r /opt/app/web-console-v2/build /opt/app/server/dist/build
 RUN rm -rf /opt/app/server/web-console-v2
 RUN npm prune --omit=dev
 
-# Stage 2 - Run the Node.js server
-FROM --platform=linux/amd64 node:24.13.1-slim
-RUN npm install -g npm@11.10.0 \
- && npm pack tar@7.5.11 \
- && tar -xzf tar-7.5.11.tgz -C /usr/local/lib/node_modules/npm/node_modules/tar --strip-components=1 \
- && rm tar-7.5.11.tgz \
- && npm pack minimatch@10.2.1 \
- && npm pack picomatch@4.0.4 \
- && npm cache clean --force \
- && cp -r /usr/local/lib/node_modules/npm/node_modules/minimatch/node_modules /tmp/minimatch_nm 2>/dev/null || true \
- && tar -xzf minimatch-10.2.1.tgz -C /usr/local/lib/node_modules/npm/node_modules/minimatch --strip-components=1 \
- && cp -r /tmp/minimatch_nm /usr/local/lib/node_modules/npm/node_modules/minimatch/node_modules 2>/dev/null || true \
- && rm -rf /tmp/minimatch_nm minimatch-10.2.1.tgz \
- && mkdir -p /usr/local/lib/node_modules/npm/node_modules/tinyglobby/node_modules/picomatch \
- && tar -xzf picomatch-4.0.4.tgz -C /usr/local/lib/node_modules/npm/node_modules/tinyglobby/node_modules/picomatch --strip-components=1 \
- && rm picomatch-4.0.4.tgz
-RUN apt-get update \
- && apt-get install -y --no-install-recommends ca-certificates openssl \
- && apt-get upgrade -y \
- && rm -rf /var/lib/apt/lists/*
+# Stage 2 - Run the Node.js server (DHI distroless runtime, non-root by default)
+FROM dhi.io/node:24-debian13
 WORKDIR /opt/app/server
-COPY --from=build /opt/app/server /opt/app/server
-COPY --from=build /opt/app/LICENSE /opt/app/LICENSE
-CMD ["npm", "run", "start:prod"]
+COPY --from=build --chown=node:node /opt/app/server /opt/app/server
+COPY --from=build --chown=node:node /opt/app/LICENSE /opt/app/LICENSE
+# start:prod is `node ./dist/index.js` — run it directly (no shell/npm in the distroless runtime)
+CMD ["node", "./dist/index.js"]

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,6 +7,7 @@
     "strict": true,
     "moduleResolution": "node",
     "esModuleInterop": true,
+    "skipLibCheck": true,
     "typeRoots": ["@types", "./node_modules/@types"]
   },
   "exclude": ["./node_modules", "./web-console-v2"]


### PR DESCRIPTION
## Summary
Pilot migration of the Docker base image to **Docker Hardened Images (DHI)** (`dhi.io`), per `DHI-MIGRATION-PLAN.md` (Category A). First repo in a phased rollout — validates the pattern before replicating across the other services.

## Changes
- **Base image:** `node:24.13.1-slim` → `dhi.io/node:24-debian13` (Node 24, Debian; closest match).
  - Build stage → `dhi.io/node:24-debian13-dev`; runtime stage → `dhi.io/node:24-debian13` (distroless, non-root by default).
- **Removed** the manual `npm@11`/`tar`/`minimatch`/`picomatch` CVE-patching block and `apt-get` steps — DHI patches these upstream.
- **Runtime CMD** `npm run start:prod` → `node ./dist/index.js` (no shell/npm in distroless runtime). Added `--chown=node:node`.
- **Dropped** `--platform=linux/amd64` pins (DHI is multi-arch).

## Pre-existing build fix (included)
The **original** `node:24.13.1-slim` Dockerfile also fails to build today (not caused by DHI): no lockfile + floating ranges means `npm install` pulls a `pg-protocol` whose `.d.ts` uses generic `Buffer<…>`, rejected by `tsc` (`TS2315`). Fix: `tsconfig.json` → `skipLibCheck: true` (idiomatic, low-risk; avoids a TS 4.9→5.x major bump).

## Verification (local)
- ✅ `docker build` green (multi-stage), ~341 MB.
- ✅ Runs as uid 1000 (non-root); app boots on Node v24.18.0, exits only at OIDC config (expected with no env).

## Follow-ups
- CI needs `dhi.io` pull access (locally pulled fine via Community tier; add creds if org mirrors).
- Dockerfile still uses `npm install` w/o lockfile → non-deterministic; future: commit lockfile + `npm ci`.
- Verify `node:24-debian13[-dev]` tags against the live catalog (DHI floats the Debian/Alpine minor).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the container runtime setup for more reliable application startup.
  * Updated the startup process to launch the built app directly.
* **Chores**
  * Streamlined the build environment to reduce setup overhead.
  * Relaxed TypeScript checking of dependency type files to speed up builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->