### PR TITLE
Release 2.2.0

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -3,3 +3,6 @@ build
 dist
 src/build
 src/node_modules
+web-console-v2/node_modules
+**/node_modules
+logs.txt

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,24 @@
+# DHI hardened build. Runtime uses the minimal shell-less debian variant — this service
+# compiles to dist/ and starts via plain `node`, so no shell/npm is needed at runtime.
+ARG BUILD_IMAGE=dhi.io/node:24-debian13-dev
+ARG RUNTIME_IMAGE=dhi.io/node:24-debian13
 
 # Stage 1 - Build the React client and Node.js server
-FROM --platform=linux/amd64 node:24.13.1-slim AS build
-RUN apt-get update \
- && apt-get install -y --no-install-recommends ca-certificates openssl \
- && apt-get upgrade -y \
- && rm -rf /var/lib/apt/lists/*
+FROM ${BUILD_IMAGE} AS build
 
-# Build React client v2
+# Production build settings: no source maps (smaller, no source leak, big memory saver on
+# emulated builds), skip the eslint plugin pass. Keeps peak RSS down for multi-arch builds.
+ENV GENERATE_SOURCEMAP=false
+ENV DISABLE_ESLINT_PLUGIN=true
+ENV NODE_OPTIONS=--max-old-space-size=3072
+
+# Build React client v2 with the app's own build (react-scripts, as before DHI). craco was
+# never part of the original build (git history + package.json use `react-scripts build`), so
+# it's dropped. `npm run build` runs react-scripts + the package.json `postbuild` script, which
+# already does `mkdir build/console && mv build/static build/console/static` — so no inline move.
 WORKDIR /opt/app/web-console-v2
+# package.json overrides cap webpack-dev-server <6 (v6 pulls express5 -> parseurl -> node:url,
+# which webpack5 won't polyfill -> react-scripts build fails). npm install resolves the capped set.
 COPY ./web-console-v2/package.json .
 RUN npm install --legacy-peer-deps
 COPY ./web-console-v2/ .
@@ -24,27 +35,10 @@ RUN cp -r /opt/app/web-console-v2/build /opt/app/server/dist/build
 RUN rm -rf /opt/app/server/web-console-v2
 RUN npm prune --omit=dev
 
-# Stage 2 - Run the Node.js server
-FROM --platform=linux/amd64 node:24.13.1-slim
-RUN npm install -g npm@11.10.0 \
- && npm pack tar@7.5.11 \
- && tar -xzf tar-7.5.11.tgz -C /usr/local/lib/node_modules/npm/node_modules/tar --strip-components=1 \
- && rm tar-7.5.11.tgz \
- && npm pack minimatch@10.2.1 \
- && npm pack picomatch@4.0.4 \
- && npm cache clean --force \
- && cp -r /usr/local/lib/node_modules/npm/node_modules/minimatch/node_modules /tmp/minimatch_nm 2>/dev/null || true \
- && tar -xzf minimatch-10.2.1.tgz -C /usr/local/lib/node_modules/npm/node_modules/minimatch --strip-components=1 \
- && cp -r /tmp/minimatch_nm /usr/local/lib/node_modules/npm/node_modules/minimatch/node_modules 2>/dev/null || true \
- && rm -rf /tmp/minimatch_nm minimatch-10.2.1.tgz \
- && mkdir -p /usr/local/lib/node_modules/npm/node_modules/tinyglobby/node_modules/picomatch \
- && tar -xzf picomatch-4.0.4.tgz -C /usr/local/lib/node_modules/npm/node_modules/tinyglobby/node_modules/picomatch --strip-components=1 \
- && rm picomatch-4.0.4.tgz
-RUN apt-get update \
- && apt-get install -y --no-install-recommends ca-certificates openssl \
- && apt-get upgrade -y \
- && rm -rf /var/lib/apt/lists/*
+# Stage 2 - Runtime (minimal, shell-less, non-root)
+FROM ${RUNTIME_IMAGE}
 WORKDIR /opt/app/server
-COPY --from=build /opt/app/server /opt/app/server
-COPY --from=build /opt/app/LICENSE /opt/app/LICENSE
-CMD ["npm", "run", "start:prod"]
+COPY --chown=node:node --from=build /opt/app/server /opt/app/server
+COPY --chown=node:node --from=build /opt/app/LICENSE /opt/app/LICENSE
+USER node
+CMD ["node", "./dist/index.js"]

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,6 +7,7 @@
     "strict": true,
     "moduleResolution": "node",
     "esModuleInterop": true,
+    "skipLibCheck": true,
     "typeRoots": ["@types", "./node_modules/@types"]
   },
   "exclude": ["./node_modules", "./web-console-v2"]

--- a/web-console-v2/package.json
+++ b/web-console-v2/package.json
@@ -88,7 +88,7 @@
     "postcss": ">=8.4.49",
     "serialize-javascript": ">=6.0.1",
     "@tootallnate/once": ">=2.0.0",
-    "webpack-dev-server": ">=5.2.1",
+    "webpack-dev-server": ">=5.2.1 <6",
     "underscore": ">=1.13.8"
   },
   "browserslist": {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved Docker image configuration for more secure, streamlined builds and runtime execution.
  * Updated container startup to run directly with Node under a non-root user.
  * Expanded ignored files and directories for cleaner Docker build contexts.

* **Bug Fixes**
  * Improved TypeScript compatibility by skipping declaration-file checks.
  * Updated development server compatibility to support newer 5.x versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->


- Base swap: node:24.13.1-slim → DHI dhi.io/node:24-debian13-dev (build) + dhi.io/node:24-debian13 (runtime).
- Runtime stage gutted: dropped the whole manual npm/tar/minimatch/picomatch vuln-patch block (DHI base already hardened). CMD npm run start:prod → node ./dist/index.js, USER node.
- craco dropped (same as mgmt-console); build memory guards added (max-old-space-size=3072).
- webpack-dev-server override >=5.2.1 → >=5.2.1 <6 (v6 pulls express5→parseurl→node:url, webpack5 won't polyfill → build fails).
- tsconfig skipLibCheck: true; .dockerignore added node_modules globs + logs.txt.