### PR TITLE
fix: resolve security vulnerabilities and upgrade react-router to v7

### DIFF
--- a/.github/workflows/build_and_deployment.yaml
+++ b/.github/workflows/build_and_deployment.yaml
@@ -1,6 +1,7 @@
 name: Obsrv web console service build and deploy workflow
 run-name: Workflow run for ${{ github.ref }}
 on:
+  # checkov:skip=CKV_GHA_7:aws-deploy is a maintainer-only deploy toggle, not build input
   push:
     tags:
       - '*'

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,7 @@ ARG BUILD_IMAGE=dhi.io/node:24-debian13-dev
 ARG RUNTIME_IMAGE=dhi.io/node:24-debian13
 
 # Stage 1 - Build the React client and Node.js server
+# checkov:skip=CKV_DOCKER_7:base images are pinned via the ARG defaults above
 FROM ${BUILD_IMAGE} AS build
 
 # Production build settings: no source maps (smaller, no source leak, big memory saver on
@@ -41,4 +42,9 @@ WORKDIR /opt/app/server
 COPY --chown=node:node --from=build /opt/app/server /opt/app/server
 COPY --chown=node:node --from=build /opt/app/LICENSE /opt/app/LICENSE
 USER node
+
+# Exec-form probe against the unauthenticated /metrics route; the runtime image has no shell.
+HEALTHCHECK --interval=30s --timeout=3s --start-period=20s --retries=3 \
+    CMD ["node", "-e", "require('http').get('http://127.0.0.1:'+(process.env.PORT||3000)+'/metrics',r=>process.exit(r.statusCode===200?0:1)).on('error',()=>process.exit(1))"]
+
 CMD ["node", "./dist/index.js"]

--- a/jest.config.js
+++ b/jest.config.js
@@ -2,4 +2,6 @@
 module.exports = {
   preset: 'ts-jest',
   testEnvironment: 'node',
+  // web-console-v2 has its own react-scripts test runner; keep this config on the server.
+  roots: ['<rootDir>/src'],
 };

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "jsonwebtoken": "^9.0.1",
     "kafkajs": "^2.2.4",
     "keycloak-connect": "^26.0.5",
-    "lodash": "^4.17.23",
+    "lodash": "^4.18.1",
     "lodash-es": "^4.17.21",
     "morgan": "^1.10.0",
     "oauth2orize": "^1.11.1",
@@ -57,7 +57,7 @@
     "pg-promise": "^11.4.3",
     "prom-client": "^14.2.0",
     "randomstring": "^1.2.3",
-    "uuid": "^9.0.0",
+    "uuid": "^11.1.1",
     "winston": "^3.8.2"
   },
   "devDependencies": {
@@ -114,6 +114,8 @@
     "nth-check": ">=2.1.1",
     "serialize-javascript": ">=6.0.1",
     "@tootallnate/once": ">=2.0.0",
-    "underscore": ">=1.13.8"
+    "underscore": ">=1.13.8",
+    "svgo": ">=2.8.3",
+    "lodash": "$lodash"
   }
 }

--- a/web-console-v2/package.json
+++ b/web-console-v2/package.json
@@ -36,10 +36,10 @@
     "formik": "2.4.6",
     "framer-motion": "^12.0.0-alpha.2",
     "history": "^5.3.0",
-    "jsonata": "2.0.4",
+    "jsonata": "2.2.0",
     "jsoneditor": "^9.10.4",
     "jsoneditor-react": "^3.1.2",
-    "lodash": "4.17.23",
+    "lodash": "4.18.1",
     "lottie-web": "^5.12.2",
     "match-sorter": "^6.3.1",
     "material-react-table": "^3.0.1",
@@ -55,13 +55,13 @@
     "react-gauge-chart": "^0.5.1",
     "react-intl": "7.0.2",
     "react-lottie": "1.2.4",
-    "react-router-dom": "^6.23.0",
+    "react-router-dom": "^7.18.0",
     "react-scripts": "5.0.1",
     "react-split-pane": "^0.1.92",
     "react-table": "7.8.0",
     "simplebar-react": "^2.4.1",
     "typescript": "^4.9.5",
-    "uuid": "^10.0.0",
+    "uuid": "^11.1.1",
     "web-vitals": "^2.1.4",
     "yup": "^1.4.0"
   },
@@ -80,6 +80,14 @@
       "react-app/jest"
     ]
   },
+  "jest": {
+    "transformIgnorePatterns": [
+      "node_modules/(?!(pretty-ms|parse-ms|pretty-bytes)/)"
+    ],
+    "moduleNameMapper": {
+      "^react-router/dom$": "<rootDir>/node_modules/react-router/dist/development/dom-export.js"
+    }
+  },
   "overrides": {
     "tar": ">=7.5.11",
     "minimatch": ">=10.2.1",
@@ -89,7 +97,12 @@
     "serialize-javascript": ">=6.0.1",
     "@tootallnate/once": ">=2.0.0",
     "webpack-dev-server": ">=5.2.1 <6",
-    "underscore": ">=1.13.8"
+    "underscore": ">=1.13.8",
+    "svgo": ">=2.8.3",
+    "sockjs": {
+      "uuid": ">=11.1.1"
+    },
+    "lodash": "$lodash"
   },
   "browserslist": {
     "production": [

--- a/web-console-v2/src/pages/DatasetCreation/SelectConnector/SelectConnector.test.tsx
+++ b/web-console-v2/src/pages/DatasetCreation/SelectConnector/SelectConnector.test.tsx
@@ -1,63 +1,106 @@
 import React from 'react';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
-import '@testing-library/jest-dom/extend-expect';
-import SelectConnector from './SelectConnector';
-import { connectorList } from '../../../components/connectorList';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { BrowserRouter } from 'react-router-dom';
+import SelectConnector from './SelectConnector';
+import { useConnectorsList } from 'services/dataset';
+
+jest.mock('services/dataset', () => ({
+  useConnectorsList: jest.fn(),
+}));
+
+const connectors = [
+  { id: 'c1', name: 'BigQuery', type: 'source', iconurl: '', category: 'Database' },
+  { id: 'c2', name: 'Kafka', type: 'source', iconurl: '', category: 'Streaming' },
+];
+
+const mockConnectorsList = (
+  { isPending = false, data = connectors } = {} as { isPending?: boolean; data?: typeof connectors },
+) => {
+  const mutate = jest.fn();
+  (useConnectorsList as jest.Mock).mockReturnValue({
+    mutate,
+    isPending,
+    data: { data: { result: { data } } },
+  });
+  return mutate;
+};
+
+const Wrapper = ({ children }: { children: React.ReactNode }) => (
+  <QueryClientProvider client={new QueryClient()}>
+    <BrowserRouter>{children}</BrowserRouter>
+  </QueryClientProvider>
+);
+
+const renderConnector = () => render(<SelectConnector />, { wrapper: Wrapper });
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockConnectorsList();
+});
 
 test('renders the SelectConnector component', () => {
-  render(<SelectConnector />, { wrapper: BrowserRouter });
-  expect(
-    screen.getByText(
-      /API connector has already pushed the data to Obsrv. You can configure additional data with it./i,
-    ),
-  ).toBeInTheDocument();
-  expect(screen.getByText(/Configure Connector/i)).toBeInTheDocument();
-  expect(
-    screen.getByPlaceholderText(/Search by connector type/i),
-  ).toBeInTheDocument();
-  expect(screen.getByPlaceholderText(/Filters/i)).toBeInTheDocument();
+  renderConnector();
+
+  expect(screen.getByText(/Choose additional data connectors/i)).toBeInTheDocument();
+  expect(screen.getByPlaceholderText(/Search by connector name/i)).toBeInTheDocument();
+  expect(screen.getByPlaceholderText(/Filter/i)).toBeInTheDocument();
+  connectors.forEach((item) => {
+    expect(screen.getByText(item.name)).toBeInTheDocument();
+  });
+});
+
+test('requests the connector list on mount', () => {
+  const mutate = mockConnectorsList();
+  renderConnector();
+
+  expect(mutate).toHaveBeenCalledWith({ payload: {} });
+});
+
+test('shows the loader while the connector list is pending', () => {
+  mockConnectorsList({ isPending: true });
+  renderConnector();
+
+  expect(screen.queryByPlaceholderText(/Search by connector name/i)).not.toBeInTheDocument();
 });
 
 test('filters connectors based on search input', async () => {
-  render(<SelectConnector />, { wrapper: BrowserRouter });
+  renderConnector();
 
-  const searchInput = screen.getByPlaceholderText(/Search by connector type/i);
-  fireEvent.change(searchInput, { target: { value: 'bigquery' } });
+  fireEvent.change(screen.getByPlaceholderText(/Search by connector name/i), {
+    target: { value: 'bigquery' },
+  });
 
   await waitFor(() => {
-    const connector1 = screen.queryByText(/Big query/i);
-    expect(connector1).toBeInTheDocument();
+    expect(screen.getByText('BigQuery')).toBeInTheDocument();
+    expect(screen.queryByText('Kafka')).not.toBeInTheDocument();
   });
 });
 
 test('selects and deselects connector card', () => {
-  render(<SelectConnector />, { wrapper: BrowserRouter });
+  renderConnector();
 
-  connectorList.forEach((item) => {
-    const connectorElements = screen.getAllByTestId('card');
+  const card = screen.getAllByTestId('card')[0];
 
-    connectorElements.forEach((connector) => {
-      fireEvent.click(connector);
+  fireEvent.click(card);
+  expect(card).toHaveClass('selectedCard');
 
-      expect(connector).toHaveClass('selectedCard');
-      fireEvent.click(connector);
-      expect(connector).not.toHaveClass('selectedCard');
-    });
-  });
+  fireEvent.click(card);
+  expect(card).not.toHaveClass('selectedCard');
 });
 
-test('displays Proceed button when a connector is selected', () => {
-  render(<SelectConnector />, { wrapper: BrowserRouter });
+test('displays Proceed button when a connector is selected and Skip when none is', () => {
+  renderConnector();
 
-  connectorList.forEach((item) => {
-    const connector = screen.getByText(item.name);
-    fireEvent.click(connector);
+  expect(screen.getByText('Skip')).toBeInTheDocument();
+  expect(screen.queryByText('Proceed')).not.toBeInTheDocument();
 
-    const proceedButton = screen.getByText(/Proceed/i);
-    expect(proceedButton).toBeInTheDocument();
+  const card = screen.getAllByTestId('card')[0];
+  fireEvent.click(card);
 
-    fireEvent.click(connector);
-    expect(proceedButton).not.toBeInTheDocument();
-  });
+  expect(screen.getByText('Proceed')).toBeInTheDocument();
+  expect(screen.queryByText('Skip')).not.toBeInTheDocument();
+
+  fireEvent.click(screen.getAllByTestId('selected-card')[0]);
+  expect(screen.getByText('Skip')).toBeInTheDocument();
 });

--- a/web-console-v2/src/setupTests.ts
+++ b/web-console-v2/src/setupTests.ts
@@ -3,3 +3,30 @@
 // expect(element).toHaveTextContent(/react/i)
 // learn more: https://github.com/testing-library/jest-dom
 import '@testing-library/jest-dom';
+import { TextEncoder, TextDecoder } from 'util';
+
+// react-router 7 needs these at module scope; CRA's jsdom does not provide them.
+global.TextEncoder = global.TextEncoder || (TextEncoder as unknown as typeof global.TextEncoder);
+global.TextDecoder = global.TextDecoder || (TextDecoder as unknown as typeof global.TextDecoder);
+
+// jsdom has no canvas backend; lottie-web probes a 2d context at import time.
+HTMLCanvasElement.prototype.getContext = jest.fn(() => ({
+    fillRect: jest.fn(),
+    clearRect: jest.fn(),
+    drawImage: jest.fn(),
+    getImageData: jest.fn(() => ({ data: new Uint8ClampedArray(4) })),
+    putImageData: jest.fn(),
+    createImageData: jest.fn(() => ({ data: new Uint8ClampedArray(4) })),
+    setTransform: jest.fn(),
+    save: jest.fn(),
+    restore: jest.fn(),
+    beginPath: jest.fn(),
+    closePath: jest.fn(),
+    moveTo: jest.fn(),
+    lineTo: jest.fn(),
+    fill: jest.fn(),
+    stroke: jest.fn(),
+    translate: jest.fn(),
+    scale: jest.fn(),
+    measureText: jest.fn(() => ({ width: 0 }))
+})) as unknown as typeof HTMLCanvasElement.prototype.getContext;


### PR DESCRIPTION
## Summary

Takes the repo from **12 Trivy findings to 1**, and that one has no fix available upstream.

| Severity | Before | After |
|---|---|---|
| CRITICAL | 0 | 0 |
| HIGH | 3 | **0** |
| MEDIUM | 7 | **0** |
| LOW | 2 | 1 |
| Misconfigurations | 1 | **0** |
| **Total** | **12** | **1** |

The remaining LOW is `elliptic@6.6.1` (CVE-2025-14505), reached via `keycloak-connect -> jwk-to-pem -> elliptic`. No patched release exists at any version, so there is nothing to pin to.

## Dependency fixes

| Package | Change | CVEs |
|---|---|---|
| lodash | 4.17.23 → 4.18.1 | CVE-2026-4800 (HIGH, RCE via `_.template` imports), CVE-2026-2950 (MEDIUM, prototype pollution) |
| jsonata | 2.0.4 → 2.2.0 | CVE-2026-52746 (HIGH, ReDoS in `$toMillis`) |
| svgo | override `>=2.8.3` | CVE-2026-73650 (HIGH, `removeScripts` bypass) |
| uuid | → 11.1.1 | CVE-2026-41907 (MEDIUM, out-of-bounds write) ×3 |
| react-router-dom | 6.30.4 → 7.18.0 | CVE-2026-53666, CVE-2026-53668, CVE-2026-53669 (all MEDIUM) |

Of these, two were genuinely reachable in this codebase: the JSONata ReDoS (the JSONata playground evaluates user-supplied expressions) and the react-router open-redirect pair. The lodash RCE was not — `_.template` is unused. Fixed regardless.

Note CVE-2026-53668 was reported as "no fix available" — that was true only for the 6.x line. It is fixed in 7.13.0, so the v7 upgrade clears all three.

## Why React Router 7 was needed, and why it was low-risk

Two of the three CVEs are only fixed in 7.18.0, so a major upgrade was the only remediation path.

**No application source changed.** The codebase uses only the stable API — `useNavigate` (29 uses), `useParams` (20), `useLocation` (11), plus `BrowserRouter`/`Routes`/`Route`/`Outlet`/`Navigate`/`NavLink`/`useSearchParams`. There is no `createBrowserRouter`, no loaders/actions, no `json()`/`defer()` — that data-router surface is where v7's breaking changes live. React 19 and Node 24 already exceeded v7's floors.

The two behavioural changes that a compiler cannot catch were both checked:
- `v7_relativeSplatPath` — only affects relative paths inside splat routes. The single splat route (`*` → NotFound) navigates absolutely via `navigate("/dashboard")`. No impact.
- `v7_startTransition` — verified by exercising browser back/forward after client-side navigation.

## Container hardening

- Added an exec-form `HEALTHCHECK` probing `/metrics`. Exec form is required because the runtime image is the shell-less DHI variant.
- Documented the two Checkov suppressions inline: `CKV_DOCKER_7` is a false positive (Checkov cannot resolve `FROM ${BUILD_IMAGE}` back to the pinned ARG defaults) and `CKV_GHA_7` is an accepted risk on the maintainer-only `aws-deploy` toggle.

Checkov now reports 0 failed / 147 passed, and Trivy's Dockerfile scan is 27/27 clean.

## Test infrastructure

These were pre-existing breakages, not caused by the dependency work. Root `npm test` was already red before this branch.

- **Scoped root jest to `src/`** — it was globbing the whole repo and pulling in `web-console-v2` `.tsx` tests that the root `tsconfig.json` explicitly excludes and cannot compile.
- **Whitelisted pure-ESM deps** (`pretty-ms`, `parse-ms`, `pretty-bytes`) in CRA's `transformIgnorePatterns`. These ship no CJS fallback. `uuid@11` and `axios` look ESM but do ship CJS builds, so they need no handling.
- **Mapped the `react-router/dom` subpath** — `react-router-dom@7` requires it internally and CRA 5's Jest resolver predates package `exports` maps. Webpack resolves it correctly, so this never affected the production build.
- **Polyfilled `TextEncoder`/`TextDecoder`** (react-router 7 uses them at module scope) and **stubbed canvas `getContext`** (lottie-web probes a 2D context at import time, which jsdom returns as `null`).
- **Rewrote `SelectConnector.test.tsx`** — it was written against an older UI and failing with "No QueryClient set". It now mocks the `useConnectorsList` hook with a fixture and wraps in `QueryClientProvider` + `BrowserRouter`. Went from 4 stale tests to 6, adding coverage for the on-mount API request and the loading state.

## Verification

**Builds and unit tests**
- Backend `tsc`: clean · frontend `react-scripts build`: compiled successfully
- Backend tests 1/1 · frontend tests 15/15 (was 3 suites failing before this branch)

**Image scan** — built amd64 and scanned: 17 findings, **0 fixable**, 0 HIGH/CRITICAL. All 17 are unpatched Debian CVEs inherited from the DHI base (16) plus `elliptic` (1). The base image alone accounts for 16 of them, so the application layer contributes exactly one. Verified arm64 and amd64 base images carry identical CVE sets.

**Deployed to the dev cluster and driven end-to-end in a real browser.** All of the following passed with **zero page errors**:
- Keycloak login → dashboard; charts, gauges and all SVG icons render
- Client-side navigation across 4 routes with no page reload; browser back/forward
- Nested routes via `<Outlet>` (`/alertRules/custom`, `/alertRules/system`)
- Full dataset-creation stepper: `connector/list/<new>` → `ingestion/meta` → `ingestion/schema/:id` → `processing/:id`, with the `:datasetId` param correctly transitioning from `<new>` to the real ID
- `navigate()` with router state (Select Connector → Proceed → configure)
- Query params preserved (`?datasetType=master`, `?step=connector&skipped=true`)
- Deep links to `/datasets`, `/connectors`, `/alertChannels`, `/userManagement` and param routes
- Splat route renders NotFound
- Connector list loads from the API; schema auto-generated from uploaded sample data; PII fields auto-detected
- JSONata transformation added and saved (exercises jsonata 2.2.0 and uuid-keyed rows)
- Dataset delete

The test dataset created during this run has been deleted.

## Not included

`TRIVY_VULNERABILITIES.md` in the working tree is a stale 2026-08-14 report and is intentionally left out of this PR.