### PR TITLE
#fix: multi platform build workflow changes

### DIFF
--- a/.github/workflows/build_and_deployment.yaml
+++ b/.github/workflows/build_and_deployment.yaml
@@ -33,9 +33,17 @@ jobs:
           username: ${{ vars.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
+      # QEMU provides the arm64 emulation the cross-arch leg needs on an amd64 runner.
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
       - name: Build docker image and push
         uses: docker/build-push-action@v4
         with:
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ vars.DOCKERHUB_USERNAME }}/obsrv-web-console:${{ github.ref_name }}
 


### PR DESCRIPTION
## Multi-platform (amd64 + arm64) container image builds

### What

Adds `linux/arm64` alongside the existing `linux/amd64` to the image build/push workflow, matching
the pattern already used by the `obsrv-automation` build workflows.

Each build job gains:

- `docker/setup-qemu-action@v3` — provides the arm64 emulation the cross-arch leg needs on an
  amd64 runner
- `docker/setup-buildx-action@v3` — required for multi-platform output; the default `docker`
  driver cannot emit a manifest list, only the `docker-container` driver buildx sets up can
- `platforms: linux/amd64,linux/arm64` on `docker/build-push-action`

Result: the published tag becomes a multi-arch manifest instead of an amd64-only image, so it runs
natively on arm64 nodes (Graviton, Apple Silicon dev machines) without emulation.

### Why

The images were amd64-only, so arm64 hosts either couldn't run them or fell back to emulation.
All base images used here already publish arm64 manifests, so nothing else had to change.

### Verification

- **actionlint** (static workflow validation) — no errors iarnings are
  pre-existing (older pinned action versions), untouched by
- **Native arm64 image build** — the Dockerfile was built for `linux/arm64` on real arm64 hardware
  (not under emulation, which can mask genuine arch failures) and the resulting image was
  inspected to confirm the expected contents and versions.
- **Base image arm64 support confirmed** via `docker manifest inspect` before making the change.
- No Dockerfile or application code is modified — this is a

### After merging, confirm the manifest is genuinely multi-

```bash
docker manifest inspect <org>/<image>:<tag>

Expect two entries, "architecture": "amd64" and "architectuifest
result means platforms did not take effect.